### PR TITLE
persist single view data on refresh

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -35,7 +35,7 @@ class App extends React.Component {
             <Route exact path="/" component={Home} />
             <Route
               exact
-              path="/results"
+              path="/trials"
               render={props => <Results {...props} userInfo={this.state.userInfo} />}
             />
 

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -69,7 +69,7 @@ class Header extends React.Component {
                 <Link to="/basic-info">Your Search</Link>
               </li>
               <li>
-                <Link to="/results">All Trials</Link>
+                <Link to="/trials">All Trials</Link>
               </li>
               <li>
                 <Link to="/faq">FAQ</Link>

--- a/src/Components/SingleResult/SingleResult.js
+++ b/src/Components/SingleResult/SingleResult.js
@@ -11,21 +11,43 @@ import { Link } from "react-router-dom";
 import "./single-result.css";
 
 const SingleResult = props => {
-  console.log(props);
+  // need to make the result persist on page refresh, it currently doesn't
+  // results achieves this by re- running the api call with either default values, or user entered values
+  // - these are stored in app.js
+  // - currently can only pass in data from props - on a click event
 
-  const { item } = props.location.params;
-  const index = props.location.params.item.IDInfo.OrgStudyID;
+  // console.log(props.location);
 
-  const title = item.Keywords ? (
-    <h3>{item.Keywords[0]}</h3>
-  ) : (
-    <h3 className="missing-data">Data Missing From API</h3>
-  );
+  let title, item;
 
-  // missing-data
+  // 1. page refreshed / visited earlier:
+  // if there are no params, try to get item from local storage
+  if (!props.location.params) {
+    // console.log("no props", props);
+    // console.log(props.location.pathname);
+
+    item = JSON.parse(localStorage.getItem(`"${props.location.pathname}"`));
+    // console.log(a);
+  }
+
+  // 2. click from results
+  else {
+    item = props.location.params;
+
+    // if there are params, add to local storage
+    localStorage.setItem(JSON.stringify(props.location.pathname), JSON.stringify(item));
+    // console.log(window.localStorage);
+
+    title = item.Keywords ? (
+      <h3>{item.Keywords[0]}</h3>
+    ) : (
+      <h3 className="missing-data">Data Missing From API</h3>
+    );
+  }
+
   return (
     <section className="main-section single-view">
-      <Link className="back-link" to="/results">
+      <Link className="back-link" to="/trials">
         <svg
           aria-labelledby="back"
           xmlns="http://www.w3.org/2000/svg"
@@ -50,7 +72,7 @@ const SingleResult = props => {
             <StartingDate />
             <Phase />
             <Summary />
-            <Keywords data={item.Keywords} style={{ padding: "100" }} />
+            <Keywords data={item.Keywords} />
           </div>
           <SaveButton />
         </div>

--- a/src/Components/SingleResult/SingleResult.js
+++ b/src/Components/SingleResult/SingleResult.js
@@ -16,34 +16,26 @@ const SingleResult = props => {
   // - these are stored in app.js
   // - currently can only pass in data from props - on a click event
 
-  // console.log(props.location);
+  let item;
 
-  let title, item;
-
-  // 1. page refreshed / visited earlier:
+  // 1. page refreshed or visited previously:
   // if there are no params, try to get item from local storage
   if (!props.location.params) {
-    // console.log("no props", props);
-    // console.log(props.location.pathname);
-
     item = JSON.parse(localStorage.getItem(`"${props.location.pathname}"`));
-    // console.log(a);
   }
 
-  // 2. click from results
+  // 2. click directly from results
+  // if there are params, add to local storage
   else {
-    item = props.location.params;
-
-    // if there are params, add to local storage
+    item = props.location.params.item;
     localStorage.setItem(JSON.stringify(props.location.pathname), JSON.stringify(item));
-    // console.log(window.localStorage);
-
-    title = item.Keywords ? (
-      <h3>{item.Keywords[0]}</h3>
-    ) : (
-      <h3 className="missing-data">Data Missing From API</h3>
-    );
   }
+
+  const title = item.Keywords ? (
+    <h3>{item.Keywords[0]}</h3>
+  ) : (
+    <h3 className="missing-data">Data Missing From API</h3>
+  );
 
   return (
     <section className="main-section single-view">


### PR DESCRIPTION
- allows single result pages to be refreshed, and data to persist
- data was previously lost, as it was **only** passed through props from the parent link (in Card.js)
- saving in state would not help, this is lost on refresh
- **Cant** go directly to a route the user **hasn't** visited yet (e.g. [http://localhost:1234/trials/Stage_III_Prostate_Cancer](http://localhost:1234/trials/Stage_III_Prostate_Cancer)), just saves data for pages that they have visited.
- Would work for bookmarks in a user's browser, but not for sharing links