### PR TITLE
fix your search form

### DIFF
--- a/src/Components/BasicInfo/BasicInfo.js
+++ b/src/Components/BasicInfo/BasicInfo.js
@@ -37,7 +37,7 @@ class BasicInfo extends React.Component {
 
     // go to all results - no consent
     if (consent === false) {
-      this.props.history.push("/results");
+      this.props.history.push("/trials");
     }
     // consent not given
     else {
@@ -57,7 +57,7 @@ class BasicInfo extends React.Component {
       else {
         if (this.state.consent === true) {
           this.props.onSubmit(this.state);
-          this.props.history.push("/results");
+          this.props.history.push("/trials");
         }
       }
     }
@@ -67,7 +67,7 @@ class BasicInfo extends React.Component {
     return (
       <section className="main-section">
         <h1>Basic Information</h1>
-        <form action="/results" className="basic-form">
+        <form action="/trials" className="basic-form">
           <h3 className="form-text">Post Code *</h3>
           <input
             onChange={this.handlePostCode}

--- a/src/Components/Card/Card.js
+++ b/src/Components/Card/Card.js
@@ -9,8 +9,6 @@ import Phase from "./Phase";
 import Summary from "./Summary";
 import Keywords from "./Keywords";
 
-import "./card.css";
-
 // get the linking thing
 import { Link } from "react-router-dom";
 
@@ -44,13 +42,21 @@ const Card = props => {
     <>
       <div className="card-inner">
         <button
-          id="delete"
+          className="delete-button"
           onClick={() => {
             props.delete(item.IDInfo.NCTID);
           }}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-            <title lang="en">Discard</title>
+          <svg
+            aria-labelledby="discard"
+            xmlns="http://www.w3.org/2000/svg"
+            width="48"
+            height="48"
+            viewBox="0 0 48 48"
+          >
+            <title id="discard" lang="en">
+              Discard
+            </title>
             <path d="M38 12.83L35.17 10 24 21.17 12.83 10 10 12.83 21.17 24 10 35.17 12.83 38 24 26.83 35.17 38 38 35.17 26.83 24z" />
           </svg>
         </button>

--- a/src/Components/Card/card.css
+++ b/src/Components/Card/card.css
@@ -1,8 +1,0 @@
-#delete {
-    float: right;
-    margin-top: -1rem;
-  }
-
-#delete:hover {
-    background-color: #e2e2e2;
-}

--- a/src/Components/Results/results.css
+++ b/src/Components/Results/results.css
@@ -123,5 +123,21 @@
   fill: white;
   position: absolute;
   top: 1rem;
-  /* left: 1rem; */
+  transition: all ease-in-out 0.3s;
+}
+.back-link:hover {
+  transform: translateX(-0.5rem);
+}
+
+.delete-button {
+  border-radius: 0.5rem;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+  transition: all ease-in-out 0.3s;
+}
+
+.delete-button:hover {
+  background-color: #e2e2e2;
 }


### PR DESCRIPTION
Sorry for doing out of hours stuff, but I noticed that the **Your Search** Form still linked to /results, and not /trials, as we changed it to today. I felt that this should be sorted, as Sola is in first thing tomorrow (20th Feb).

Branch name comes from my original intention - look into distance of trial to user postcode

**I also did the following:**
- styled the delete button with a class, not an id (one id per page)
- marked up the delete svg with an aria label and title tag
- put delete button styles in results.css (where most card styles reside), removed card.css
    - It might be a good idea to do an audit of the css, and get a better system for managing it. I notice css classes have been getting duplicated a lot across components lately.]
- add some snazzy transitions to button elements